### PR TITLE
モデルを追加

### DIFF
--- a/app/models/chat.rb
+++ b/app/models/chat.rb
@@ -1,0 +1,2 @@
+class Chat < ApplicationRecord
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,2 @@
+class Comment < ApplicationRecord
+end

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -1,0 +1,2 @@
+class Favorite < ApplicationRecord
+end

--- a/app/models/matching.rb
+++ b/app/models/matching.rb
@@ -1,0 +1,2 @@
+class Matching < ApplicationRecord
+end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,0 +1,2 @@
+class Notification < ApplicationRecord
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,0 +1,2 @@
+class Post < ApplicationRecord
+end

--- a/app/models/post_tag.rb
+++ b/app/models/post_tag.rb
@@ -1,0 +1,2 @@
+class PostTag < ApplicationRecord
+end

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -1,0 +1,2 @@
+class Room < ApplicationRecord
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,2 @@
+class Tag < ApplicationRecord
+end

--- a/app/models/user_notification.rb
+++ b/app/models/user_notification.rb
@@ -1,0 +1,2 @@
+class UserNotification < ApplicationRecord
+end

--- a/app/models/user_room.rb
+++ b/app/models/user_room.rb
@@ -1,0 +1,2 @@
+class UserRoom < ApplicationRecord
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,10 @@
 Rails.application.routes.draw do
-  devise_for :users
   devise_for :admins, controllers: {
     sessions: "admin/sessions"
+  }
+  devise_for :users, controllers: {
+    registrations: "public/registrations",
+    sessions: "public/sessions"
   }
   
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html

--- a/db/migrate/20230206075153_create_posts.rb
+++ b/db/migrate/20230206075153_create_posts.rb
@@ -1,0 +1,14 @@
+class CreatePosts < ActiveRecord::Migration[6.1]
+  def change
+    create_table :posts do |t|
+      t.integer "user_id", null: false
+      t.integer "room_id", null: false
+      t.string "title", null: false
+      t.text "body", null: false
+      t.string "time", null: false
+      t.string "place", null: false
+      t.string "belonging", null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230206075720_create_post_tags.rb
+++ b/db/migrate/20230206075720_create_post_tags.rb
@@ -1,0 +1,10 @@
+class CreatePostTags < ActiveRecord::Migration[6.1]
+  def change
+    create_table :post_tags do |t|
+    # PostとTagの中間テーブル
+      t.integer "post_id", null: false
+      t.integer "tag_id", null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230206075923_create_tags.rb
+++ b/db/migrate/20230206075923_create_tags.rb
@@ -1,0 +1,8 @@
+class CreateTags < ActiveRecord::Migration[6.1]
+  def change
+    create_table :tags do |t|
+      t.string "name", null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230206080046_create_favorites.rb
+++ b/db/migrate/20230206080046_create_favorites.rb
@@ -1,0 +1,9 @@
+class CreateFavorites < ActiveRecord::Migration[6.1]
+  def change
+    create_table :favorites do |t|
+      t.integer "user_id", null: false
+      t.integer "post_id", null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230206080201_create_comments.rb
+++ b/db/migrate/20230206080201_create_comments.rb
@@ -1,0 +1,9 @@
+class CreateComments < ActiveRecord::Migration[6.1]
+  def change
+    create_table :comments do |t|
+      t.integer "user_id", null: false
+      t.integer "post_id", null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230206080422_create_user_notifications.rb
+++ b/db/migrate/20230206080422_create_user_notifications.rb
@@ -1,0 +1,9 @@
+class CreateUserNotifications < ActiveRecord::Migration[6.1]
+  def change
+    create_table :user_notifications do |t|
+      t.integer "visitor_id", null: false
+      t.integer "visited_id", null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230206080555_create_notifications.rb
+++ b/db/migrate/20230206080555_create_notifications.rb
@@ -1,0 +1,14 @@
+class CreateNotifications < ActiveRecord::Migration[6.1]
+  def change
+    create_table :notifications do |t|
+      t.integer "user_notification_id", null: false
+      t.integer "post_id", null: false
+      t.integer "chat_id", null: false
+      t.integer "favorite_id", null: false
+      t.integer "comment_id", null: false
+      t.string "action", null: false
+      t.boolean "checked", default: false, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230206081220_create_matchings.rb
+++ b/db/migrate/20230206081220_create_matchings.rb
@@ -1,0 +1,9 @@
+class CreateMatchings < ActiveRecord::Migration[6.1]
+  def change
+    create_table :matchings do |t|
+      t.integer "follower_id", null: false
+      t.integer "following_id", null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230206081335_create_user_rooms.rb
+++ b/db/migrate/20230206081335_create_user_rooms.rb
@@ -1,0 +1,10 @@
+class CreateUserRooms < ActiveRecord::Migration[6.1]
+  def change
+    create_table :user_rooms do |t|
+      # UserとRoomの中間テーブル
+      t.integer "user_id", null: false
+      t.integer "room_id", null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230206081456_create_chats.rb
+++ b/db/migrate/20230206081456_create_chats.rb
@@ -1,0 +1,10 @@
+class CreateChats < ActiveRecord::Migration[6.1]
+  def change
+    create_table :chats do |t|
+      t.integer "user_id", null: false
+      t.integer "room_id", null: false
+      t.text "message", null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230206081657_create_rooms.rb
+++ b/db/migrate/20230206081657_create_rooms.rb
@@ -1,0 +1,8 @@
+class CreateRooms < ActiveRecord::Migration[6.1]
+  def change
+    create_table :rooms do |t|
+      t.integer "post_id", null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_02_06_074047) do
+ActiveRecord::Schema.define(version: 2023_02_06_081657) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -50,6 +50,92 @@ ActiveRecord::Schema.define(version: 2023_02_06_074047) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["email"], name: "index_admins_on_email", unique: true
     t.index ["reset_password_token"], name: "index_admins_on_reset_password_token", unique: true
+  end
+
+  create_table "chats", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "room_id", null: false
+    t.text "message", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "comments", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "post_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "favorites", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "post_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "matchings", force: :cascade do |t|
+    t.integer "follower_id", null: false
+    t.integer "following_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "notifications", force: :cascade do |t|
+    t.integer "user_notification_id", null: false
+    t.integer "post_id", null: false
+    t.integer "chat_id", null: false
+    t.integer "favorite_id", null: false
+    t.integer "comment_id", null: false
+    t.string "action", null: false
+    t.boolean "checked", default: false, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "post_tags", force: :cascade do |t|
+    t.integer "post_id", null: false
+    t.integer "tag_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "posts", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "room_id", null: false
+    t.string "title", null: false
+    t.text "body", null: false
+    t.string "time", null: false
+    t.string "place", null: false
+    t.string "belonging", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "rooms", force: :cascade do |t|
+    t.integer "post_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "user_notifications", force: :cascade do |t|
+    t.integer "visitor_id", null: false
+    t.integer "visited_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "user_rooms", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "room_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "users", force: :cascade do |t|

--- a/test/fixtures/chats.yml
+++ b/test/fixtures/chats.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/favorites.yml
+++ b/test/fixtures/favorites.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/matchings.yml
+++ b/test/fixtures/matchings.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/notifications.yml
+++ b/test/fixtures/notifications.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/post_tags.yml
+++ b/test/fixtures/post_tags.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/posts.yml
+++ b/test/fixtures/posts.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/rooms.yml
+++ b/test/fixtures/rooms.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/tags.yml
+++ b/test/fixtures/tags.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/user_notifications.yml
+++ b/test/fixtures/user_notifications.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/user_rooms.yml
+++ b/test/fixtures/user_rooms.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/chat_test.rb
+++ b/test/models/chat_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ChatTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CommentTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/favorite_test.rb
+++ b/test/models/favorite_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class FavoriteTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/matching_test.rb
+++ b/test/models/matching_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class MatchingTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class NotificationTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/post_tag_test.rb
+++ b/test/models/post_tag_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class PostTagTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class PostTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/room_test.rb
+++ b/test/models/room_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class RoomTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class TagTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/user_notification_test.rb
+++ b/test/models/user_notification_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UserNotificationTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/user_room_test.rb
+++ b/test/models/user_room_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UserRoomTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
追加済のdevise(User, Admin)以外のモデルを追加しました。

【変更点】
・Postモデルの追加
・PostTagモデルの追加（PostとTagの中間テーブル）
・Tagモデルの追加
・Favoriteモデルの追加
・Commentモデルの追加
・UserNotificationモデルの追加（UserとNotificationの中間テーブル）
・Notificationモデルの追加
・Matchingモデルの追加
・UserRoomモデルの追加（UserとRoomの中間テーブル）
・Chatモデルの追加
・Roomモデルの追加
・deviseのusersに関わるルーティング修正