### PR TITLE
各種レイアウト調整（Top, ユーザー詳細等）

### DIFF
--- a/app/controllers/admin/posts_controller.rb
+++ b/app/controllers/admin/posts_controller.rb
@@ -1,7 +1,10 @@
 class Admin::PostsController < ApplicationController
   
   def index
-    @posts = params[:tag_id].present? ? Tag.find(params[:tag_id]).posts : Post.status_public.order(created_at: :desc).page(params[:page])
+    @posts = params[:tag_id].present? ? Tag.find(params[:tag_id]).posts.page(params[:page]) : Post.status_public.order(created_at: :desc).page(params[:page])
+    if params[:user_id]
+      @posts = Post.status_public.where(user_id: params[:user_id]).order(created_at: :desc).page(params[:page])
+    end
   end
   
   def show

--- a/app/controllers/public/posts_controller.rb
+++ b/app/controllers/public/posts_controller.rb
@@ -20,7 +20,7 @@ class Public::PostsController < ApplicationController
   def index
     @posts = params[:tag_id].present? ? Tag.find(params[:tag_id]).posts.page(params[:page]) : Post.status_public.order(created_at: :desc).page(params[:page])
     if params[:user_id]
-      @posts = Post.where(user_id: params[:user_id]).order(created_at: :desc).page(params[:page])
+      @posts = Post.status_public.where(user_id: params[:user_id]).order(created_at: :desc).page(params[:page])
     end
   end
   

--- a/app/views/admin/posts/index.html.erb
+++ b/app/views/admin/posts/index.html.erb
@@ -1,8 +1,10 @@
 <div class="container-fluid w-75 my-3">
   <div class="row">
     <div class="col-3">
-      <%= render "search_word" %>
-      <%= render "search_tag" %>
+      <% if params[:user_id].blank? %>
+        <%= render "search_word" %>
+        <%= render "search_tag" %>
+      <% end %>
     </div>
     <div class="col-9">
       <h2 class="font-weight-bold">＜投稿一覧＞</h2>

--- a/app/views/admin/rooms/index.html.erb
+++ b/app/views/admin/rooms/index.html.erb
@@ -4,7 +4,7 @@
   <table class="w-100" style="table-layout: fixed;">
     <thead>
       <tr class="table table-secondary text-center">
-        <th scope="col" width="20%">ユーザー</th>
+        <th scope="col" width="20%">投稿者</th>
         <th scope="col" width="20%">タイトル</th>
         <th scope="col">メッセージ</th>
         <th scope="col" width="15%"></th>
@@ -15,7 +15,7 @@
       <tr class="border-bottom text-center">
         <td>
           <%= link_to admin_room_path(room.id) do %>
-            <%= room.users.name %>
+            <%= room.post.user.name %>
           <% end %>
         </td>
         <td>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -62,7 +62,7 @@
   
   <div class="row">
     <div class="col text-right">
-      <p><%= link_to admin_posts_path(@user) do %><u>過去の投稿</u><% end %></p>
+      <p><%= link_to admin_posts_path(user_id: @user.id) do %><u>過去の投稿</u><% end %></p>
     </div>
   </div>
 </div>

--- a/app/views/public/homes/top.html.erb
+++ b/app/views/public/homes/top.html.erb
@@ -34,13 +34,13 @@
   </div>
   
   <!--新着投稿（最新8件）-->
-  <div class="row mt-5">
+  <div class="row mt-3">
     <div class="col ml-3">
       <h3 class="font-weight-bold">＜ 新着投稿 ＞</h3>
       <% if user_signed_in? %>
         <% if @posts.present? %>
           <%= render "public/posts/latest_posts", posts: @posts %>
-          <p class="text-right"><u><%= link_to "全ての投稿を見る", posts_path %></u></p>
+          <p class="text-right mt-3"><u><%= link_to "全ての投稿を見る", posts_path %></u></p>
         <% else %>
           <p class="text-center my-5">投稿が見つかりませんでした</p>
         <% end %>

--- a/app/views/public/posts/_latest_posts.html.erb
+++ b/app/views/public/posts/_latest_posts.html.erb
@@ -1,10 +1,12 @@
 <% posts.each do |post| %>
-  <div class="card d-inline-flex" style="width: 12%; height: 350px">
-    <%= image_tag post.get_image(200, 200) %>
+  <div class="card d-inline-flex" style="width: 12%; height: 380px;">
+    <div class="card-img flex-row text-center" style="width: 200px; height: 200px;">
+      <%= image_tag post.get_image(200, 200), class: "h-100" %>
+    </div>
     <div class="card-body">
-      <h5 class="card-title"><%= truncate(post.title, length: 10) %></h5>
-      <p class="card-text"><%= truncate(post.body, length: 30) %></p>
-      <%= link_to "詳細", post_path(post.id), class: "btn btn-info" %>
+      <h5 class="card-title"><%= truncate(post.title, length: 9) %></h5>
+      <p class="card-text mb-0" style="height: 72px;"><%= truncate(post.body, length: 33) %></p>
+      <p class="text-right"><%= link_to "詳細", post_path(post.id), class: "btn btn-info" %></p>
     </div>
   </div>
 <% end %>

--- a/app/views/public/posts/index.html.erb
+++ b/app/views/public/posts/index.html.erb
@@ -1,8 +1,10 @@
 <div class="container-fluid w-75 my-3">
   <div class="row">
     <div class="col-3">
-      <%= render "search_word" %>
-      <%= render "search_tag" %>
+      <% if params[:user_id].blank? %>
+        <%= render "search_word" %>
+        <%= render "search_tag" %>
+      <% end %>
       <% if current_user.name != "guestuser" %>
         <h5 class="font-weight-bold mt-5">＜新規投稿＞</h5>
         <p><%= link_to "投稿を作成する", new_post_path, class: "btn btn-info" %></p>

--- a/app/views/public/users/show.html.erb
+++ b/app/views/public/users/show.html.erb
@@ -42,27 +42,48 @@
           </tr>
         </table>
       </div>
+      <div class="col-8">
+        <table class="table table-bordered">
+          <tr>
+            <th scope="row" class="table-secondary">ユーザー名</th>
+            <td><%= @user.display_name %></td>
+          </tr>
+          <tr>
+            <th scope="row" class="table-secondary">都道府県</th>
+            <td><%= @user.prefecture %></td>
+          </tr>
+          <tr>
+            <th scope="row" class="table-secondary">市区町村</th>
+            <td><%= @user.municipality %></td>
+          </tr>
+          <tr>
+            <th scope="row" class="table-secondary">自己紹介</th>
+            <td><%= simple_format(h(@user.self_introduction)) %></td>
+          </tr>
+        </table>
+      </div>
+    <% else %>
+      <div class="col-8 mx-auto">
+        <table class="table table-bordered" style="table-layout: fixed;">
+          <tr>
+            <th scope="row" class="table-secondary" width="25%">ユーザー名</th>
+            <td><%= @user.display_name %></td>
+          </tr>
+          <tr>
+            <th scope="row" class="table-secondary">都道府県</th>
+            <td><%= @user.prefecture %></td>
+          </tr>
+          <tr>
+            <th scope="row" class="table-secondary">市区町村</th>
+            <td><%= @user.municipality %></td>
+          </tr>
+          <tr>
+            <th scope="row" class="table-secondary">自己紹介</th>
+            <td><%= simple_format(h(@user.self_introduction)) %></td>
+          </tr>
+        </table>
+      </div>
     <% end %>
-    <div class="col-8">
-      <table class="table table-bordered">
-        <tr>
-          <th scope="row" class="table-secondary">ユーザー名</th>
-          <td><%= @user.display_name %></td>
-        </tr>
-        <tr>
-          <th scope="row" class="table-secondary">都道府県</th>
-          <td><%= @user.prefecture %></td>
-        </tr>
-        <tr>
-          <th scope="row" class="table-secondary">市区町村</th>
-          <td><%= @user.municipality %></td>
-        </tr>
-        <tr>
-          <th scope="row" class="table-secondary">自己紹介</th>
-          <td><%= simple_format(h(@user.self_introduction)) %></td>
-        </tr>
-      </table>
-    </div>
   </div>
   
   <div class="row">


### PR DESCRIPTION
各種レイアウト調整を行いました。
主な変更点は下記の通りです。

（変更点）
・Topページ 新着投稿欄のレイアウト調整
・他のユーザーから見たユーザー詳細画面のレイアウト調整
・過去の投稿を表示した際に、検索欄を表示しないよう調整（※何れ表示させたい）
・管理者側でチャットルーム一覧を表示した際に、投稿者名を表示するよう調整