### PR TITLE
チャット機能のデバッグ

### DIFF
--- a/app/controllers/public/posts_controller.rb
+++ b/app/controllers/public/posts_controller.rb
@@ -38,17 +38,26 @@ class Public::PostsController < ApplicationController
     end
     
     # 投稿詳細からマッチング後、「チャットを始める」ボタンを押すと、両者にチャットルームが作成される
-    @current_user_room = UserRoom.where(user_id: current_user.id)
-    @another_user_room = UserRoom.where(user_id: @user.id)
+    # @current_user_room = UserRoom.where(user_id: current_user.id)
+    # @another_user_room = UserRoom.where(user_id: @user.id)
+    @user_rooms = UserRoom.eager_load(:room).where(user_id: [current_user.id, @user.id]).where(room: {post_id: @post.id})
+    # @another_user_room = UserRoom.joins(:room).where(user_id: @user.id).where(room_id: @post.id)
+    # @post_room = Room.where(post_id: @post.id)
     # マッチングしている場合、チャットルームのリンクを表示する
-    @current_user_room.each do |current_user|
-      @another_user_room.each do |another_user|
-        if current_user.room_id == another_user.room_id then
-          @is_room = true
-          @room_id = current_user.room_id
-        end
-      end
+    @is_room = false
+    if @user_rooms.exists?(user_id: current_user.id)
+      @is_room = true
+      @room_id = @user_rooms.find_by(user_id: current_user.id).room_id
     end
+    # byebug
+    # @current_user_room.each do |current_user|
+    #   @another_user_room.each do |another_user|
+    #     if current_user.room_id == another_user.room_id then
+    #       @is_room = true
+    #       @room_id = current_user.room_id
+    #     end
+    #   end
+    # end
     # マッチングしていない場合、チャットルームを作成する
     unless @is_room
       @room = Room.new

--- a/app/views/public/posts/show.html.erb
+++ b/app/views/public/posts/show.html.erb
@@ -74,12 +74,13 @@
                   <%= f.submit "チャットへ", class: "btn btn-primary" %>
                 <% end %>
               <% else %>
-                <%= fields_for @user_room do |ur| %>
+               <%= fields_for @user_room do |ur| %>
                   <%= ur.hidden_field :user_id, value: @user.id %>
                 <% end %>
+                
                 <%= f.hidden_field :post_id, value: @post.id %>
                 <%= f.submit "チャットを始める", class: "btn btn-primary" %>
-              <% end %>
+              <% end %> 
             <% end %>
           <% end %>
         </div>


### PR DESCRIPTION
投稿毎にチャットルーム（フォロー・フォロワー）を作成できるようにしました。
①投稿者をフォローしている状態で、「チャットへ」ボタンを押下
①-1（新規の場合）
→2人の新規チャットルームを作成
①-2 （既に①-1でチャットルームが作成されている場合）
→既に作成されているチャットルームへ移動
※"投稿毎に"上記の動作が実行される。
　そのため、既にユーザーAとユーザーBの間にチャットルームがあっても、投稿が違えばチャットルームは新規作成される。
