### PR TITLE
各種レイアウト調整（投稿詳細、通知一覧等）

### DIFF
--- a/app/controllers/public/posts_controller.rb
+++ b/app/controllers/public/posts_controller.rb
@@ -75,7 +75,7 @@ class Public::PostsController < ApplicationController
   
   # 非公開（下書き）の投稿一覧
   def draft
-    @posts = params[:tag_id].present? ? Tag.find(params[:tag_id]).posts : Post.status_private.order(created_at: :desc).page(params[:page])
+    @posts = params[:tag_id].present? ? Tag.find(params[:tag_id]).posts : Post.status_private.where(user_id: current_user.id).order(created_at: :desc).page(params[:page])
   end
   
   private

--- a/app/controllers/public/sessions_controller.rb
+++ b/app/controllers/public/sessions_controller.rb
@@ -22,7 +22,7 @@ class Public::SessionsController < Devise::SessionsController
   protected
   
     # サインアップ後の遷移先
-    def after_sign_up_path_fot(resource)
+    def after_sign_up_path_for(resource)
       user_path(current_user.id)
     end
   
@@ -36,12 +36,12 @@ class Public::SessionsController < Devise::SessionsController
       root_path
     end
 
-    # ログイン時の入力情報
+    # ログイン時の入力情報を規定
     def user_state
       @user = User.find_by(email: params[:user][:email])
       return if !@user
       if @user.valid_password?(params[:user][:password]) && !(@user.is_deleted == false)
-        redirect_to new_user_registration_path
+        redirect_to new_user_registration_path, danger: "退会済のユーザーです"
       end
     end
     

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -12,10 +12,9 @@
           <% end %>
         </a>
       <% end %>
-      <!--ヘッダー右-->
+      <!--ヘッダー右(ユーザー/ゲストユーザーログイン時)-->
       <div class="collapse navbar-collapse">
         <ul class="navbar-nav ml-auto mr-5">
-        <!--ユーザー/ゲストユーザーログイン時-->
           <% if user_signed_in? %>
             <% if current_user.name != "guestuser" %>
               <li class="nav-item">
@@ -35,7 +34,7 @@
               <% end %>
             </li>
             <li class="nav-item ml-3">
-              <%= link_to rooms_path(current_user), class: "btn btn-outline-light" do %>
+              <%= link_to rooms_path(user_id: current_user.id), class: "btn btn-outline-light" do %>
                 <i class="fas fa-comments"></i>チャット一覧
               <% end %>
             </li>

--- a/app/views/public/favorites/index.html.erb
+++ b/app/views/public/favorites/index.html.erb
@@ -1,5 +1,5 @@
 <!--いいねした投稿一覧-->
-<div class="container-fluid mt-3">
+<div class="container-fluid w-75 mt-3">
   <h2 class="font-weight-bold">＜いいねした投稿＞</h2>
   
   <!--いいねした投稿一覧表示-->
@@ -12,9 +12,9 @@
       <th scope="col">タグ</th>
       <th scope="col">日時</th>
       <th scope="col">場所</th>
-      <th scope="col">いいね</th>
-      <th scope="col">コメント</th>
-      <th scope="col"></th>
+      <th scope="col" width="8%">いいね</th>
+      <th scope="col" width="10%">コメント</th>
+      <th scope="col" width="8%"></th>
     </tr>
     <% @favorited_posts.each do |post| %>
     <tr>

--- a/app/views/public/notifications/index.html.erb
+++ b/app/views/public/notifications/index.html.erb
@@ -3,13 +3,15 @@
   <h2 class="font-weight-bold">＜通知一覧＞</h2>
   
   <!--通知一覧表示-->
-  <% if @notifications.present? %>
-    <% @notifications.each do |notification| %>
-      <%= render "notifications", notification: notification %>
+  <div class="notification-list my-3">
+    <% if @notifications.present? %>
+      <% @notifications.each do |notification| %>
+        <%= render "notifications", notification: notification %>
+      <% end %>
+    <% else %>
+      <p class="text-center">通知はありません</p>
     <% end %>
-  <% else %>
-    <p class="text-center my-5">通知はありません</p>
-  <% end %>
+  </div>
   
   <!--ページネーション-->
   <div class="pagination justify-content-center">

--- a/app/views/public/posts/edit.html.erb
+++ b/app/views/public/posts/edit.html.erb
@@ -9,7 +9,7 @@
 <% end %>
 
 <!--投稿編集-->
-<div class="container mt-3">
+<div class="container my-3">
   <h2 class="font-weight-bold">＜投稿編集画面＞</h2>
   <%= form_with model: @post do |f| %>
     <div class="form-group field">

--- a/app/views/public/posts/show.html.erb
+++ b/app/views/public/posts/show.html.erb
@@ -23,7 +23,7 @@
           <p>#<%= tag.name %></p>
         <% end %>
       </div>
-      <div class="post-user mt-3">
+      <div class="post-user my-3">
         <p class="font-weight-bold mb-0">投稿者</p>
         <%= link_to user_path(@user) do %>
           <%= image_tag @user.get_profile_image(120, 120), class: "rounded-circle" %><br>

--- a/app/views/public/users/show.html.erb
+++ b/app/views/public/users/show.html.erb
@@ -67,7 +67,7 @@
           </tr>
         </table>
       </div>
-    <!--他のユーザーの表示-->
+    <!--他のユーザーから見た表示-->
     <% else %>
       <div class="col-8 mx-auto">
         <table class="table table-bordered" style="table-layout: fixed;">


### PR DESCRIPTION
各種レイアウトの調整を行いました。
主な変更点は下記の通りです。

（変更点）
・投稿詳細画面、投稿編集画面におけるフッターとの隙間を追加
・いいねした投稿一覧の表示幅をw-75に修正
・非公開（下書き）一覧に他の投稿者の下書きも表示される不具合を修正
・通知一覧のページネーション位置を調整
・ルーム一覧を表示するパスでuser_idを正しく渡すよう修正
・退会済のユーザーがログインボタンを押下した際に、フラッシュメッセージを表示するよう更新