### PR TITLE
チャット時の表示名を修正

### DIFF
--- a/app/views/admin/chats/_chat_messages.html.erb
+++ b/app/views/admin/chats/_chat_messages.html.erb
@@ -4,7 +4,7 @@
     <tr>
       <td width="20%">
         <%= image_tag chat.user.get_profile_image(100, 100), class: "rounded-circle" %><br>
-        <%= chat.user.name %>
+        <%= chat.user.display_name %>
       </td>
       <td>
         <h6><%= simple_format(h(chat.message)) %></h6>

--- a/app/views/admin/rooms/index.html.erb
+++ b/app/views/admin/rooms/index.html.erb
@@ -16,7 +16,7 @@
         <tr class="border-bottom text-center">
           <td>
             <%= link_to admin_room_path(room.id) do %>
-              <%= room.post.user.name %>
+              <%= room.post.user.display_name %>
             <% end %>
           </td>
           <td>

--- a/app/views/public/chats/_chat_messages.html.erb
+++ b/app/views/public/chats/_chat_messages.html.erb
@@ -9,14 +9,14 @@
         </td>
         <td width="10%">
           <%= image_tag chat.user.get_profile_image(100, 100), class: "rounded-circle" %><br>
-          <%= simple_format(h(chat.user.name)) %>
+          <%= simple_format(h(chat.user.display_name)) %>
         </td>
       </tr>
     <% else %>
       <tr class="text-left">
         <td width="10%">
           <%= image_tag chat.user.get_profile_image(100, 100), class: "rounded-circle" %><br>
-          <%= chat.user.name %>
+          <%= chat.user.display_name %>
         </td>
         <td>
           <h6><%= chat.message %></h6>

--- a/app/views/public/rooms/index.html.erb
+++ b/app/views/public/rooms/index.html.erb
@@ -17,7 +17,7 @@
         <td>
           <%= link_to room_path(aur.room.id) do %>
             <%= image_tag aur.user.get_profile_image(100, 100), class: "rounded-circle" %><br>
-            <%= aur.user.name %>
+            <%= aur.user.display_name %>
           <% end %>
         </td>
         <td>


### PR DESCRIPTION
チャット一覧画面、チャット詳細画面において、ユーザー名の表示を氏名でなく表示名となるよう修正しました。