### PR TITLE
チャット時にユーザー名からプロフィールに遷移できるよう更新

### DIFF
--- a/app/views/admin/chats/_chat_messages.html.erb
+++ b/app/views/admin/chats/_chat_messages.html.erb
@@ -3,8 +3,10 @@
   <table class="w-100" style="table-layout: fixed;">
     <tr>
       <td width="20%">
-        <%= image_tag chat.user.get_profile_image(100, 100), class: "rounded-circle" %><br>
-        <%= chat.user.display_name %>
+        <%= link_to admin_user_path(chat.user) do %>
+          <%= image_tag chat.user.get_profile_image(100, 100), class: "rounded-circle" %><br>
+          <%= chat.user.display_name %>
+        <% end %>
       </td>
       <td>
         <h6><%= simple_format(h(chat.message)) %></h6>

--- a/app/views/public/chats/_chat_messages.html.erb
+++ b/app/views/public/chats/_chat_messages.html.erb
@@ -8,15 +8,19 @@
           <h6 style="color: #C0C0C0;"><%= chat.created_at.strftime("%Y/%m/%d %H:%M") %></h6>
         </td>
         <td width="10%">
-          <%= image_tag chat.user.get_profile_image(100, 100), class: "rounded-circle" %><br>
-          <%= simple_format(h(chat.user.display_name)) %>
+          <%= link_to user_path(chat.user) do %>
+            <%= image_tag chat.user.get_profile_image(100, 100), class: "rounded-circle" %><br>
+            <%= simple_format(h(chat.user.display_name)) %>
+          <% end %>
         </td>
       </tr>
     <% else %>
       <tr class="text-left">
         <td width="10%">
-          <%= image_tag chat.user.get_profile_image(100, 100), class: "rounded-circle" %><br>
-          <%= chat.user.display_name %>
+          <%= link_to user_path(chat.user) do %>
+            <%= image_tag chat.user.get_profile_image(100, 100), class: "rounded-circle" %><br>
+            <%= chat.user.display_name %>
+          <% end %>
         </td>
         <td>
           <h6><%= chat.message %></h6>


### PR DESCRIPTION
チャット詳細画面にて、プロフィール画像 / ユーザー名から当該ユーザーの詳細画面に遷移できるよう更新しました。