### PR TITLE
チャット表示に関する変更

### DIFF
--- a/app/views/admin/rooms/index.html.erb
+++ b/app/views/admin/rooms/index.html.erb
@@ -25,7 +25,7 @@
           <td>
             <% if room.chats.present? %>
               <% chat = Chat.find_by(id: room.chat_ids.last).message %>
-              <%= truncate(chat, length: 10) %>
+              <%= truncate(chat, length: 30) %>
             <% else %>
               <p class="text-center my-5">チャットを始めましょう</p>
             <% end %>

--- a/app/views/public/chats/_chat_messages.html.erb
+++ b/app/views/public/chats/_chat_messages.html.erb
@@ -4,7 +4,7 @@
     <% if chat.user_id == current_user.id %>
       <tr class="text-right">
         <td>
-          <h6><%= chat.message %></h6>
+          <h6><%= simple_format(h(chat.message)) %></h6>
           <h6 style="color: #C0C0C0;"><%= chat.created_at.strftime("%Y/%m/%d %H:%M") %></h6>
         </td>
         <td width="10%">
@@ -23,7 +23,7 @@
           <% end %>
         </td>
         <td>
-          <h6><%= chat.message %></h6>
+          <h6><%= simple_format(h(chat.message)) %></h6>
           <h6 style="color: #C0C0C0;"><%= chat.created_at.strftime("%Y/%m/%d %H:%M") %></h6>
         </td>
       </tr>

--- a/app/views/public/chats/_form_chat.html.erb
+++ b/app/views/public/chats/_form_chat.html.erb
@@ -3,7 +3,7 @@
   <div class="chat_form form-group field mb-0 py-5">
     <%= f.label "新しいメッセージ", class: "control-label" %>
     <%= f.hidden_field :room_id %>
-    <%= f.text_field :message, class: "form-control" %>
+    <%= f.text_area :message, class: "form-control", rows: "1" %>
     <%= f.submit "送信する", class: "my-2" %>
   </div>
 <% end %>

--- a/app/views/public/rooms/index.html.erb
+++ b/app/views/public/rooms/index.html.erb
@@ -26,7 +26,7 @@
         <td>
           <% if aur.room.chats.present? %>
             <% chat = Chat.find_by(id: aur.room.chat_ids.last).message %>
-            <%= truncate(chat, length: 10) %>
+            <%= truncate(chat, length: 30) %>
           <% else %>
             <p class="text-center my-5">チャットを始めましょう</p>
           <% end %>


### PR DESCRIPTION
チャット表示について変更しました。
主な変更点は下記の通りです。

（変更点）
・チャット一覧の最新メッセージの表示文字数を変更（10→30）
・チャットフォームで入力する際に改行できるよう変更（表示も併せて修正）