### PR TITLE
チャット表示幅の調整、管理者側の2重チャットタイトルの修正他

### DIFF
--- a/app/views/admin/chats/_chat_messages.html.erb
+++ b/app/views/admin/chats/_chat_messages.html.erb
@@ -1,17 +1,34 @@
 <!--チャットメッセージ-->
 <% chats.each do |chat| %>
   <table class="w-100" style="table-layout: fixed;">
-    <tr>
-      <td width="20%">
+    <% if chat.user_id == chat.room.post.user.id %>
+    <tr class="text-right">
+      <td width="10%"></td>
+      <td width="80%">
+        <h6><%= simple_format(h(chat.message)) %></h6>
+        <h6 style="color: #C0C0C0;"><%= chat.created_at.strftime("%Y/%m/%d %H:%M") %></h6>
+      </td>
+      <td width="10%">
+        <%= link_to admin_user_path(chat.room.post.user) do %>
+          <%= image_tag chat.room.post.user.get_profile_image(100, 100), class: "rounded-circle" %><br>
+          <%= chat.room.post.user.display_name %>
+        <% end %>
+      </td>
+    </tr>
+    <% else %>
+    <tr class="text-left">
+      <td width="10%">
         <%= link_to admin_user_path(chat.user) do %>
           <%= image_tag chat.user.get_profile_image(100, 100), class: "rounded-circle" %><br>
           <%= chat.user.display_name %>
         <% end %>
       </td>
-      <td>
+      <td width="80%">
         <h6><%= simple_format(h(chat.message)) %></h6>
         <h6 style="color: #C0C0C0;"><%= chat.created_at.strftime("%Y/%m/%d %H:%M") %></h6>
       </td>
+      <td width="10%"></td>
     </tr>
+    <% end %>
   </table>
 <% end %>

--- a/app/views/admin/rooms/show.html.erb
+++ b/app/views/admin/rooms/show.html.erb
@@ -5,11 +5,7 @@
     <%= link_to "削除", admin_room_path, method: :delete, class: "btn btn-danger" %>
   </div>
   <div class="row justify-content-center py-3">
-    <% @user_rooms.each do |ur| %>
-      <% if ur.user != current_user %>
-        <h2><u><%= link_to "#{ur.room.post.title}", post_path(ur.room.post) %></u></h2>
-      <% end %>
-    <% end %>
+    <h2><u><%= link_to "#{@room.post.title}", admin_post_path(@room.post) %></u></h2>
   </div>
   
   <!--チャットメッセージ-->

--- a/app/views/public/chats/_chat_messages.html.erb
+++ b/app/views/public/chats/_chat_messages.html.erb
@@ -3,7 +3,8 @@
   <table class="w-100" style="table-layout: fixed;">
     <% if chat.user_id == current_user.id %>
       <tr class="text-right">
-        <td>
+        <td width="10%"></td>
+        <td width="80%">
           <h6><%= simple_format(h(chat.message)) %></h6>
           <h6 style="color: #C0C0C0;"><%= chat.created_at.strftime("%Y/%m/%d %H:%M") %></h6>
         </td>
@@ -22,10 +23,11 @@
             <%= chat.user.display_name %>
           <% end %>
         </td>
-        <td>
+        <td width="80%">
           <h6><%= simple_format(h(chat.message)) %></h6>
           <h6 style="color: #C0C0C0;"><%= chat.created_at.strftime("%Y/%m/%d %H:%M") %></h6>
         </td>
+        <td width="10%"></td>
       </tr>
     <% end %>
   </table>

--- a/app/views/public/chats/_form_chat.html.erb
+++ b/app/views/public/chats/_form_chat.html.erb
@@ -3,7 +3,7 @@
   <div class="chat_form form-group field mb-0 py-5">
     <%= f.label "新しいメッセージ", class: "control-label" %>
     <%= f.hidden_field :room_id %>
-    <%= f.text_area :message, class: "form-control", rows: "1" %>
+    <%= f.text_area :message, class: "form-control", rows: "1", placeholder: "メッセージを入力してください" %>
     <%= f.submit "送信する", class: "my-2" %>
   </div>
 <% end %>


### PR DESCRIPTION
チャット画面のレイアウトについて、一部変更しました。
主な変更点は下記の通りです。

（変更点）
・チャットメッセージの表示幅を調整
・入力フォームにplaceholderを追加（メッセージを入力してください）
・管理者側のチャット詳細画面で投稿タイトルが2重になっている不具合を解消