### PR TITLE
退会済ユーザーをチャット詳細画面に表示

### DIFF
--- a/app/controllers/admin/rooms_controller.rb
+++ b/app/controllers/admin/rooms_controller.rb
@@ -6,7 +6,18 @@ class Admin::RoomsController < ApplicationController
   def show
     @room = Room.find(params[:id])
     @chats = @room.chats
-    @user_rooms = @room.user_rooms
+    
+    # 退会済ユーザーの情報を取得し、チャット画面上部に表示（最大２名）
+    user_ids = @room.user_rooms.pluck(:user_id)
+    users = User.where(id: user_ids).where(is_deleted: true)
+    user_names = users.pluck(:display_name)
+    if users.present?
+      if users.count == 2
+        flash.now[:danger] = "#{user_names[0]}, #{user_names[1]}は退会済のユーザーです"
+      else
+        flash.now[:danger] = "#{user_names[0]}は退会済のユーザーです"
+      end
+    end
   end
 
   def destroy

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
 
-  # フラッシュメッセージにBootstrapのスタイルを適用
+  # リダイレクト時のフラッシュメッセージにBootstrapのスタイルを適用
   add_flash_types :success, :info, :warning, :danger
 
   protected

--- a/app/controllers/public/rooms_controller.rb
+++ b/app/controllers/public/rooms_controller.rb
@@ -28,6 +28,15 @@ class Public::RoomsController < ApplicationController
     else
       redirect_to request.referer
     end
+    
+    # 退会済ユーザーの情報を取得し、チャット画面上部に表示（最大1名）
+    user_ids = @user_rooms.pluck(:user_id)
+    users = User.where(id: user_ids).where(is_deleted: true)
+    if users.present?
+      users.each do |user|
+        flash.now[:danger] = "#{user.display_name}は退会済のユーザーです"
+      end
+    end
   end
 
   private

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,4 +1,4 @@
-<!--フラッシュメッセージ-->
+<!--フラッシュメッセージ（Bootstrapのalertを適用）-->
 <% flash.each do |key, value| %>
   <%= content_tag(:div, value, class: "alert alert-#{key} mb-0") %>
 <% end %>


### PR DESCRIPTION
退会済ユーザーがいる場合、チャット詳細画面にフラッシュメッセージで表示するよう変更しました。