### PR TITLE
画像表示の修正他

### DIFF
--- a/app/controllers/admin/rooms_controller.rb
+++ b/app/controllers/admin/rooms_controller.rb
@@ -13,9 +13,9 @@ class Admin::RoomsController < ApplicationController
     user_names = users.pluck(:display_name)
     if users.present?
       if users.count == 2
-        flash.now[:danger] = "#{user_names[0]}, #{user_names[1]}は退会済のユーザーです"
+        flash.now[:info] = "#{user_names[0]}, #{user_names[1]}は退会済のユーザーです"
       else
-        flash.now[:danger] = "#{user_names[0]}は退会済のユーザーです"
+        flash.now[:info] = "#{user_names[0]}は退会済のユーザーです"
       end
     end
   end

--- a/app/controllers/public/rooms_controller.rb
+++ b/app/controllers/public/rooms_controller.rb
@@ -34,7 +34,7 @@ class Public::RoomsController < ApplicationController
     users = User.where(id: user_ids).where(is_deleted: true)
     if users.present?
       users.each do |user|
-        flash.now[:danger] = "#{user.display_name}は退会済のユーザーです"
+        flash.now[:info] = "#{user.display_name}は退会済のユーザーです"
       end
     end
   end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -40,7 +40,7 @@ class Post < ApplicationRecord
       file_path = Rails.root.join("app/assets/images/no_image_square.jpeg")
       image.attach(io: File.open(file_path), filename: "default-sports-image.jpg", content_type: "image/jpeg")
     end
-    image.variant(resize_to_limit: [width, height]).processed
+    image.variant(resize: "#{width}x#{height}!").processed
   end
 
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,7 +32,7 @@ class User < ApplicationRecord
       file_path = Rails.root.join("app/assets/images/no_image.jpeg")
       profile_image.attach(io: File.open(file_path), filename: "default-image.jpg", content_type: "image/jpeg")
     end
-    profile_image.variant(resize_to_limit: [width, height]).processed
+    profile_image.variant(resize: "#{width}x#{height}!").processed
   end
 
   # 退会済のユーザーをログインさせない

--- a/app/views/admin/posts/show.html.erb
+++ b/app/views/admin/posts/show.html.erb
@@ -22,7 +22,7 @@
       <div class="post-user my-3">
         <p class="font-weight-bold mb-0">投稿者</p>
         <%= link_to admin_user_path(@user) do %>
-          <%= image_tag @user.get_profile_image(120, 120), class: "rounded-circle" %><br>
+          <%= image_tag @user.get_profile_image(120, 120), class: "rounded-circle my-2" %><br>
           <%= @user.display_name %>
         <% end %>
       </div>

--- a/app/views/public/posts/_latest_posts.html.erb
+++ b/app/views/public/posts/_latest_posts.html.erb
@@ -2,7 +2,7 @@
 <% posts.each do |post| %>
   <div class="card d-inline-flex" style="width: 12%; height: 380px;">
     <div class="card-img flex-row text-center" style="width: 200px; height: 200px;">
-      <%= image_tag post.get_image(200, 200), class: "h-100" %>
+      <%= image_tag post.get_image(215, 200), class: "h-100" %>
     </div>
     <div class="card-body">
       <h5 class="card-title"><%= truncate(post.title, length: 9) %></h5>

--- a/app/views/public/users/show.html.erb
+++ b/app/views/public/users/show.html.erb
@@ -23,7 +23,7 @@
   <!--プロフィール画像-->
   <div class="row">
     <div class="col text-center">
-      <%= image_tag @user.get_profile_image(300, 300), class: "rounded-circle" %>
+      <%= image_tag @user.get_profile_image(300, 300), class: "rounded-circle my-2" %>
     </div>
   </div>
   


### PR DESCRIPTION
ユーザー / 投稿の画像表示について、変更しました。
主な変更点は下記の通りです。

（変更点）
・プロフィール / 投稿画像のresize修正（アスペクト比を無視）
・プロフィール画像の上下にマージンを追加
・新着投稿一覧に表示される画像サイズを調整