### PR TITLE
非公開投稿に関わるコードの更新他

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   # リダイレクト時のフラッシュメッセージにBootstrapのスタイルを適用
-  add_flash_types :success, :info, :warning, :danger
+  add_flash_types :success, :info, :warning, :danger, :secondary
 
   protected
     # サインアップ時の入力情報を追加（ユーザー名、氏名、電話番号）

--- a/app/controllers/public/posts_controller.rb
+++ b/app/controllers/public/posts_controller.rb
@@ -12,7 +12,11 @@ class Public::PostsController < ApplicationController
     tag = Tag.find(params[:post][:tag_ids])
     @post.tags << tag
     if @post.save
-      redirect_to posts_path, success: "投稿しました"
+      if @post.status_public?
+        redirect_to posts_path, success: "投稿しました"
+      else
+        redirect_to post_draft_path(current_user), secondary: "非公開（下書き）にしました"
+      end
     else
       render :new
     end
@@ -78,7 +82,7 @@ class Public::PostsController < ApplicationController
 
   # 非公開（下書き）の投稿一覧
   def draft
-    @posts = params[:tag_id].present? ? Tag.find(params[:tag_id]).posts : Post.status_private.where(user_id: current_user.id).order(created_at: :desc).page(params[:page])
+    @posts = Post.status_private.where(user_id: current_user.id).order(created_at: :desc).page(params[:page])
   end
 
   private

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -31,7 +31,7 @@ class Post < ApplicationRecord
     end
 
     posts = posts.order(created_at: :desc).page(page)
-    posts
+    return posts
   end
 
   # デフォルト画像の設定、画像サイズの指定方法


### PR DESCRIPTION
非公開投稿に関わるコードの更新等を行いました。
主な変更点は下記の通りです。

（変更点）
・非公開（下書き）で投稿した際のリダイレクト先を非公開（下書き）投稿一覧へ変更
・postsコントローラーのdraftメソッドを一部修正
・フラッシュメッセージにsecondaryを追加