### PR TITLE
フッターをブラウザの最下部に固定

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,3 +13,20 @@
  *= require_tree .
  *= require_self
  */
+
+//コンテンツ量に関わらずフッターを最下部に表示 
+.FixedFooterBottom{
+  min-height: 100vh; //コンテンツ高さの最小値=ブラウザの高さ
+  position: relative; //footerを相対位置で指定
+  padding-bottom: 60px; //footer直上のコンテンツとの間隔
+  box-sizing: border-box;
+}
+
+footer{
+  position: absolute; //footerの絶対位置
+  bottom: 0; //ブラウザの一番下
+  width: 100%;
+  height: 50px;
+  background-color: #365E94;
+  color: white;
+}

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,6 +1,4 @@
 <!--フッター-->
-<footer>
-  <div style="background-color: #365E94;">
-    <h6 class="text-center text-white mb-0 py-3">©️︎TBan34</h6>
-  </div>
+<footer class="d-flex align-items-center justify-content-center">
+  <h6 class="mb-0">©️︎TBan34</h6>
 </footer>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,14 +6,16 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
-    <%= stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+    <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>
 
   <body>
-    <%= render "layouts/header" %>
-    <%= render "layouts/flash" %>
-    <%= yield %>
-    <%= render "layouts/footer" %>
+    <div class="FixedFooterBottom">
+      <%= render "layouts/header" %>
+      <%= render "layouts/flash" %>
+      <%= yield %>
+      <%= render "layouts/footer" %>
+    </div>
   </body>
 </html>


### PR DESCRIPTION
フッターをコンテンツの量に関わらずブラウザの最下部に表示できる様変更しました。
また、CSSの管理をassets/stylesheets下で行えるよう変更しました。