### PR TITLE
Post, Notificationモデルのカラム名を変更

### DIFF
--- a/app/controllers/admin/posts_controller.rb
+++ b/app/controllers/admin/posts_controller.rb
@@ -30,6 +30,6 @@ class Admin::PostsController < ApplicationController
 
   private
     def post_params
-      params.require(:post).permit(:user_id, :title, :body, :time, :place, :belonging, :image)
+      params.require(:post).permit(:user_id, :title, :body, :since_when, :at_where, :for_playing, :image)
     end
 end

--- a/app/controllers/public/notifications_controller.rb
+++ b/app/controllers/public/notifications_controller.rb
@@ -2,8 +2,8 @@ class Public::NotificationsController < ApplicationController
   # ユーザー詳細画面におけるユーザーIDを基に、当該ユーザーの通知一覧を表示
   # 通知一覧を開いた際に、これまでの通知は確認されたものとする
   def index
-    if params[:visited_id]
-      @notifications = User.find_by(id: params[:visited_id]).passive_notifications.order(created_at: :desc).page(params[:page])
+    if params[:receiver_id]
+      @notifications = User.find_by(id: params[:receiver_id]).passive_notifications.order(created_at: :desc).page(params[:page])
       @notifications.where(checked: false).each do |notification|
         notification.update(checked: true)
       end
@@ -12,6 +12,6 @@ class Public::NotificationsController < ApplicationController
 
   private
     def notification_params
-      params.require(:notification).permit(:visited_id)
+      params.require(:notification).permit(:receiver_id)
     end
 end

--- a/app/controllers/public/posts_controller.rb
+++ b/app/controllers/public/posts_controller.rb
@@ -78,7 +78,7 @@ class Public::PostsController < ApplicationController
 
   private
     def post_params
-      params.require(:post).permit(:user_id, :title, :body, :time, :place, :belonging, :image, :status)
+      params.require(:post).permit(:user_id, :title, :body, :since_when, :at_where, :for_playing, :image, :status)
     end
 
     # 投稿者以外が投稿を編集できないよう制限

--- a/app/models/chat.rb
+++ b/app/models/chat.rb
@@ -13,8 +13,8 @@ class Chat < ApplicationRecord
     end
   end
 
-  def save_notification_chat!(current_user, visited_id)
-    notification = current_user.active_notifications.new(chat_id: id, visited_id: visited_id, action: "chat")
+  def save_notification_chat!(current_user, receiver_id)
+    notification = current_user.active_notifications.new(chat_id: id, receiver_id: receiver_id, action: "chat")
     notification.save if notification.valid?
   end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,6 +1,6 @@
 class Notification < ApplicationRecord
-  belongs_to :visitor, class_name: "User", foreign_key: "visitor_id"
-  belongs_to :visited, class_name: "User", foreign_key: "visited_id"
+  belongs_to :sender, class_name: "User", foreign_key: "sender_id"
+  belongs_to :receiver, class_name: "User", foreign_key: "receiver_id"
   belongs_to :post, optional: true
   belongs_to :comment, optional: true
   belongs_to :chat, optional: true

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -11,9 +11,9 @@ class Post < ApplicationRecord
   has_one_attached :image
 
   validates :title, presence: true
-  validates :time, presence: true
-  validates :place, presence: true
-  validates :belonging, presence: true
+  validates :since_when, presence: true
+  validates :at_where, presence: true
+  validates :for_playing, presence: true
   validates :body, presence: true
 
   # 投稿の公開・非公開を設定
@@ -67,16 +67,16 @@ class Post < ApplicationRecord
 
   # キーワード検索（部分一致）
   def self.search_word(search_word)
-    @post = Post.where("title LIKE? OR body LIKE? OR time LIKE? OR place LIKE?", 
+    @post = Post.where("title LIKE? OR body LIKE? OR since_when LIKE? OR at_where LIKE?", 
     "%#{search_word}%", "%#{search_word}%", "%#{search_word}%", "%#{search_word}%")
   end
 
   # いいね通知の作成（投稿に対して他のユーザーから初めていいねされた場合）
   def create_notification_favorite!(current_user)
-    temp_favorite = Notification.where(["visitor_id = ? and visited_id = ? and post_id = ? and action = ?", current_user.id, user_id, id, "favorite"])
+    temp_favorite = Notification.where(["sender_id = ? and receiver_id = ? and post_id = ? and action = ?", current_user.id, user_id, id, "favorite"])
     if temp_favorite.blank?
-      notification = current_user.active_notifications.new(post_id: id, visited_id: user_id, action: "favorite")
-      notification.checked = false unless notification.visitor_id != notification.visited_id
+      notification = current_user.active_notifications.new(post_id: id, receiver_id: user_id, action: "favorite")
+      notification.checked = false unless notification.sender_id != notification.receiver_id
       notification.save if notification.valid?
     end
   end
@@ -90,9 +90,9 @@ class Post < ApplicationRecord
     save_notification_comment!(current_user, comment_id, user_id) if temp_users.blank?
   end
 
-  def save_notification_comment!(current_user, comment_id, visited_id)
-    notification = current_user.active_notifications.new(post_id: id, comment_id: comment_id, visited_id: visited_id, action: "comment")
-    notification.checked = false unless notification.visitor_id != notification.visited_id
+  def save_notification_comment!(current_user, comment_id, receiver_id)
+    notification = current_user.active_notifications.new(post_id: id, comment_id: comment_id, receiver_id: receiver_id, action: "comment")
+    notification.checked = false unless notification.sender_id != notification.receiver_id
     notification.save if notification.valid?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,8 +14,8 @@ class User < ApplicationRecord
   has_many :user_rooms, dependent: :destroy
   has_many :rooms, through: :user_rooms
   has_many :chats
-  has_many :active_notifications, class_name: "Notification", foreign_key: "visitor_id", dependent: :destroy
-  has_many :passive_notifications, class_name: "Notification", foreign_key: "visited_id", dependent: :destroy
+  has_many :active_notifications, class_name: "Notification", foreign_key: "sender_id", dependent: :destroy
+  has_many :passive_notifications, class_name: "Notification", foreign_key: "receiver_id", dependent: :destroy
 
   # プロフィール画像を添付
   has_one_attached :profile_image
@@ -70,9 +70,9 @@ class User < ApplicationRecord
 
   # フォロー（マッチング）通知の作成
   def create_notification_follow!(current_user)
-    temp = Notification.where(["visitor_id = ? and visited_id = ? and action = ?", current_user.id, id, "follow"])
+    temp = Notification.where(["sender_id = ? and receiver_id = ? and action = ?", current_user.id, id, "follow"])
     if temp.blank?
-      notification = current_user.active_notifications.new(visited_id: id, action: "follow")
+      notification = current_user.active_notifications.new(receiver_id: id, action: "follow")
       notification.save if notification.valid?
     end
   end

--- a/app/views/admin/posts/_posts_table.html.erb
+++ b/app/views/admin/posts/_posts_table.html.erb
@@ -24,8 +24,8 @@
           <% end %>
         <% end %>
       </td>
-      <td><%= post.time.strftime("%Y/%m/%d %H:%M") %></td>
-      <td><%= post.place %></td>
+      <td><%= post.since_when.strftime("%Y/%m/%d %H:%M") %></td>
+      <td><%= post.at_where %></td>
       <td style="color: red">♥<%= post.favorites.count %></td>
       <td><%= post.comments.count %>件</td>
       <td><%= link_to "詳細", admin_post_path(post.id) %></td>

--- a/app/views/admin/posts/edit.html.erb
+++ b/app/views/admin/posts/edit.html.erb
@@ -26,15 +26,15 @@
     </div>
     <div class="form-group field">
       <%= f.label :"日時", class: "control-label" %>
-      <%= f.datetime_field :time, class: "form-control col-sm-6" %>
+      <%= f.datetime_field :since_when, class: "form-control col-sm-6" %>
     </div>
     <div class="form-group field">
       <%= f.label :"場所", class: "control-label" %>
-      <%= f.text_field :place, class: "form-control col-sm-6" %>
+      <%= f.text_field :at_where, class: "form-control col-sm-6" %>
     </div>
     <div class="form-group field">
       <%= f.label :"持ち物", class: "control-label" %>
-      <%= f.text_field :belonging, class: "form-control col-sm-6" %>
+      <%= f.text_field :for_playing, class: "form-control col-sm-6" %>
     </div>
     <div class="form-group field">
       <%= f.label :"詳細情報", class: "control-label" %>

--- a/app/views/admin/posts/show.html.erb
+++ b/app/views/admin/posts/show.html.erb
@@ -39,15 +39,15 @@
         </tr>
         <tr>
           <th scope="row" class="table-secondary">日時</th>
-          <td><%= @post.time %></td>
+          <td><%= @post.since_when %></td>
         </tr>
         <tr>
           <th scope="row" class="table-secondary">場所</th>
-          <td><%= @post.place %></td>
+          <td><%= @post.at_where %></td>
         </tr>
         <tr>
           <th scope="row" class="table-secondary">持ち物</th>
-          <td><%= @post.belonging %></td>
+          <td><%= @post.for_playing %></td>
         </tr>
         <tr>
           <th scope="row" class="table-secondary">詳細情報</th>

--- a/app/views/public/notifications/_notifications.html.erb
+++ b/app/views/public/notifications/_notifications.html.erb
@@ -1,11 +1,11 @@
 <!--通知一覧表示-->
-<% visitor = notification.visitor %>
-<% visited = notification.visited %>
+<% sender = notification.sender %>
+<% receiver = notification.receiver %>
   <div class="d-flex justify-content-between border-bottom">
     <span>
-      <%= link_to user_path(visitor) do %>
-        <%= image_tag visitor.get_profile_image(50, 50), class: "rounded-circle" %>
-        <%= visitor.display_name %>
+      <%= link_to user_path(sender) do %>
+        <%= image_tag sender.get_profile_image(50, 50), class: "rounded-circle" %>
+        <%= sender.display_name %>
       <% end %>
       さんが
       <% case notification.action
@@ -14,7 +14,7 @@
         <% when "favorite" then %>
           <%= link_to "あなたの投稿", notification.post %>にいいねしました
         <% when "comment" then %>
-          <% if notification.post.user_id == visited.id %>
+          <% if notification.post.user_id == receiver.id %>
             <%= link_to "あなたの投稿", notification.post %>にコメントしました
           <% else %>
             <%= link_to post_path(notification.post) do %>
@@ -24,7 +24,7 @@
             にコメントしました
           <% end %>
         <% when "chat" then %>
-          <% if notification.chat.user_id == visitor.id %>
+          <% if notification.chat.user_id == sender.id %>
             <%= link_to room_path(notification.chat.room_id) do %>
               チャット
             <% end %>

--- a/app/views/public/posts/_form.html.erb
+++ b/app/views/public/posts/_form.html.erb
@@ -13,15 +13,15 @@
 </div>
 <div class="form-group field">
   <%= f.label :"日時", class: "control-label" %>
-  <%= f.datetime_field :time, class: "form-control col-sm-6" %>
+  <%= f.datetime_field :since_when, class: "form-control col-sm-6" %>
 </div>
 <div class="form-group field">
   <%= f.label :"場所", class: "control-label" %>
-  <%= f.text_field :place, class: "form-control col-sm-6" %>
+  <%= f.text_field :at_where, class: "form-control col-sm-6" %>
 </div>
 <div class="form-group field">
   <%= f.label :"持ち物", class: "control-label" %>
-  <%= f.text_field :belonging, class: "form-control col-sm-6" %>
+  <%= f.text_field :for_playing, class: "form-control col-sm-6" %>
 </div>
 <div class="form-group field">
   <%= f.label :"詳細情報", class: "control-label" %>

--- a/app/views/public/posts/_posts_table.html.erb
+++ b/app/views/public/posts/_posts_table.html.erb
@@ -26,8 +26,8 @@
               <% end %>
             <% end %>
           </td>
-          <td><%= post.time.strftime("%Y/%m/%d %H:%M") %></td>
-          <td><%= post.place %></td>
+          <td><%= post.since_when.strftime("%Y/%m/%d %H:%M") %></td>
+          <td><%= post.at_where %></td>
           <td style="color: red">♥<%= post.favorites.count %></td>
           <td><%= post.comments.count %>件</td>
           <td><%= link_to "詳細", post_path(post.id) %></td>

--- a/app/views/public/posts/show.html.erb
+++ b/app/views/public/posts/show.html.erb
@@ -43,15 +43,15 @@
         </tr>
         <tr>
           <th scope="row" class="table-secondary">日時</th>
-          <td><%= @post.time.strftime("%Y/%m/%d %H:%M") %></td>
+          <td><%= @post.since_when.strftime("%Y/%m/%d %H:%M") %></td>
         </tr>
         <tr>
           <th scope="row" class="table-secondary">場所</th>
-          <td><%= @post.place %></td>
+          <td><%= @post.at_where %></td>
         </tr>
         <tr>
           <th scope="row" class="table-secondary">持ち物</th>
-          <td><%= @post.belonging %></td>
+          <td><%= @post.for_playing %></td>
         </tr>
         <tr>
           <th scope="row" class="table-secondary">詳細情報</th>

--- a/app/views/public/users/show.html.erb
+++ b/app/views/public/users/show.html.erb
@@ -8,11 +8,11 @@
       <div class="col-10 offset-2 text-right">
         <%= link_to "編集", edit_user_path(@user.id), class: "btn btn-success" %>
         <% if current_user.passive_notifications.where(checked: false).any? %>
-          <%= link_to notifications_path(visited_id: @user.id), class: "btn btn-warning text-white ml-3" do %>
+          <%= link_to notifications_path(receiver_id: @user.id), class: "btn btn-warning text-white ml-3" do %>
             通知<i class="fas fa-exclamation-circle"></i>
           <% end %>
         <% else %>
-          <%= link_to "通知", notifications_path(visited_id: @user.id), class: "btn btn-warning text-white ml-3" %>
+          <%= link_to "通知", notifications_path(receiver_id: @user.id), class: "btn btn-warning text-white ml-3" %>
         <% end %>
         <%= link_to "いいねした投稿", user_favorites_path(@user.id), class: "btn btn-info ml-3" %>
         <%= link_to "非公開（下書き）一覧", post_draft_path(current_user), class: "btn btn-secondary ml-3" %>

--- a/db/migrate/20230206075153_create_posts.rb
+++ b/db/migrate/20230206075153_create_posts.rb
@@ -5,9 +5,9 @@ class CreatePosts < ActiveRecord::Migration[6.1]
       t.integer "room_id", null: true
       t.string "title", null: false
       t.text "body", null: false
-      t.string "time", null: false
-      t.string "place", null: false
-      t.string "belonging", null: false
+      t.datetime "since_when", null: false
+      t.string "at_where", null: false
+      t.string "for_playing", null: false
       t.integer "status", null: false, default: 0
       t.timestamps
     end

--- a/db/migrate/20230206080555_create_notifications.rb
+++ b/db/migrate/20230206080555_create_notifications.rb
@@ -1,8 +1,8 @@
 class CreateNotifications < ActiveRecord::Migration[6.1]
   def change
     create_table :notifications do |t|
-      t.integer "visitor_id", null: false
-      t.integer "visited_id", null: false
+      t.integer "sender_id", null: false
+      t.integer "receiver_id", null: false
       t.integer "post_id"
       t.integer "comment_id"
       t.integer "chat_id"

--- a/db/migrate/20230309105819_rename_time_column_to_posts.rb
+++ b/db/migrate/20230309105819_rename_time_column_to_posts.rb
@@ -1,5 +1,0 @@
-class RenameTimeColumnToPosts < ActiveRecord::Migration[6.1]
-  def change
-    change_column :posts, :time, :datetime
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_03_09_105819) do
+ActiveRecord::Schema.define(version: 2023_02_06_081657) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -83,8 +83,8 @@ ActiveRecord::Schema.define(version: 2023_03_09_105819) do
   end
 
   create_table "notifications", force: :cascade do |t|
-    t.integer "visitor_id", null: false
-    t.integer "visited_id", null: false
+    t.integer "sender_id", null: false
+    t.integer "receiver_id", null: false
     t.integer "post_id"
     t.integer "comment_id"
     t.integer "chat_id"
@@ -106,9 +106,9 @@ ActiveRecord::Schema.define(version: 2023_03_09_105819) do
     t.integer "room_id"
     t.string "title", null: false
     t.text "body", null: false
-    t.datetime "time", null: false
-    t.string "place", null: false
-    t.string "belonging", null: false
+    t.datetime "since_when", null: false
+    t.string "at_where", null: false
+    t.string "for_playing", null: false
     t.integer "status", default: 0, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false


### PR DESCRIPTION
Post, Notificationモデルのカラム名を変更しました。
また、それに伴いモデル、コントローラ、ビューファイルのコードを修正しました。
変更したカラムは以下の通りです。

（変更点）
・Postモデル
→日時：time => since_when, 場所：place => at_where, 持ち物：belonging => for_playing
・Notificationモデル
→通知者：visitor_id => sender_id, 被通知者：visited_id => receiver_id