### PR TITLE
他のユーザーがチャットルームへ侵入しようとする際のアクセス制限追加他

### DIFF
--- a/app/controllers/public/posts_controller.rb
+++ b/app/controllers/public/posts_controller.rb
@@ -1,5 +1,5 @@
 class Public::PostsController < ApplicationController
-  before_action :is_post_user?, only: [:edit, :update, :destroy]
+  before_action :is_contributor_themselves?, only: [:edit, :update, :destroy]
 
   def new
     @post = Post.new
@@ -81,7 +81,7 @@ class Public::PostsController < ApplicationController
     end
 
     # 投稿者以外が投稿を編集できないよう制限
-    def is_post_user?
+    def is_contributor_themselves?
       @post = Post.find(params[:id])
       user_id = @post.user.id
       unless user_id == current_user.id

--- a/app/controllers/public/rooms_controller.rb
+++ b/app/controllers/public/rooms_controller.rb
@@ -1,4 +1,6 @@
 class Public::RoomsController < ApplicationController
+  before_action :is_participant_themselves?, only: [:show]
+  
   def create
     @room = Room.create(room_params)
     @user_room_1 = UserRoom.create(user_id: current_user.id, room_id: @room.id)
@@ -42,5 +44,15 @@ class Public::RoomsController < ApplicationController
   private
     def room_params
       params.require(:room).permit(:post_id)
+    end
+    
+    # 当事者以外がチャットルームに入れないよう制限
+    def is_participant_themselves?
+      @room = Room.find(params[:id])
+      @user_rooms = @room.user_rooms
+      collaborator_ids = @user_rooms.pluck(:user_id)
+      unless collaborator_ids.include?(current_user.id)
+        redirect_to root_path
+      end
     end
 end

--- a/app/controllers/public/users_controller.rb
+++ b/app/controllers/public/users_controller.rb
@@ -1,6 +1,6 @@
 class Public::UsersController < ApplicationController
-  before_action :is_login_user?,    only: [:edit, :update]
-  before_action :ensure_guest_user, only: [:edit]
+  before_action :is_user_themselves?, only: [:edit, :update]
+  before_action :ensure_guest_user,   only: [:edit]
 
   def show
     @user = User.find(params[:id])
@@ -33,7 +33,7 @@ class Public::UsersController < ApplicationController
     end
 
     # 本人以外がユーザー情報を編集できないよう制限
-    def is_login_user?
+    def is_user_themselves?
       user_id = params[:id].to_i
       unless user_id == current_user.id
         redirect_to root_path

--- a/app/views/admin/posts/edit.html.erb
+++ b/app/views/admin/posts/edit.html.erb
@@ -19,7 +19,7 @@
       </div>
       <div class="form-group field">
         <%= f.label :"タグ ※最大5個まで", class: "control-label" %><br>
-        <%= f.text_field :tag, value: @post.tags.pluck(:name).join(','), placeholder: "野球 キャッチボール 初心者", class: "form-control col-sm-6" %>
+        <%= f.text_field :tag, value: @post.tags.pluck(:name), placeholder: "野球 キャッチボール 初心者", class: "form-control col-sm-6" %>
       </div>
       <div class="form-group field">
         <%= f.label :"タイトル", class: "control-label" %>

--- a/app/views/public/posts/_form.html.erb
+++ b/app/views/public/posts/_form.html.erb
@@ -5,7 +5,7 @@
 </div>
 <div class="form-group field">
   <%= f.label :"タグ ※最大5個まで", class: "control-label" %><br>
-  <%= f.text_field :tag, value: post.tags.pluck(:name).join(','), placeholder: "野球 キャッチボール 初心者", class: "form-control col-sm-6" %>
+  <%= f.text_field :tag, value: post.tags.pluck(:name), placeholder: "野球 キャッチボール 初心者", class: "form-control col-sm-6" %>
 </div>
 <div class="form-group field">
   <%= f.label :"タイトル", class: "control-label" %>


### PR DESCRIPTION
他のユーザーからのチャットルームへのアクセス制限をかけました。
主な変更点は以下の通りです。

（変更点）
・マッチングユーザー以外のユーザーがリンクからチャットルームへ侵入しようとした際に、
　トップページへリダイレクトさせる制限を追加。
※仕様上、他のユーザーのチャットルーム一覧を閲覧しようとしても、チャットルームが見つからないか、
  自分とのチャットルームしか表示されないようになっている。
・ユーザー情報 / 投稿情報の編集制限ついて、メソッド名を変更。
・複数タグの間をjoin(",")ではなく、空白で繋ぐよう記述修正。