### PR TITLE
コメント通知/表示の修正

### DIFF
--- a/app/views/admin/comments/_comment_list.html.erb
+++ b/app/views/admin/comments/_comment_list.html.erb
@@ -2,14 +2,14 @@
 <p>【コメント一覧】</p>
 <% post.comments.each do |comment| %>
   <table class="CommentList">
-    <td style="width: 10%">
+    <td style="width: 8%">
       <%= image_tag comment.user.get_profile_image(100, 100), class: "rounded-circle" %>
     </td>
-    <td style="width: 10%">
-      <%= comment.user.name %>
+    <td style="width: 12%">
+      <%= comment.user.display_name %>
     </td>
     <td style="width: 70%">
-      <%= simple_format(h(comment.content)) %>
+      <%= simple_format(h(comment.content), class: "my-0") %>
     </td>
     <td class="text-center" style="width: 10%">
       <%= link_to "削除", admin_post_comment_path(comment.post, comment), method: :delete, remote: true, class: "btn btn-danger" %>

--- a/app/views/public/comments/_comment_list.html.erb
+++ b/app/views/public/comments/_comment_list.html.erb
@@ -3,14 +3,14 @@
 <% if current_user != User.guest %>
   <% post.comments.each do |comment| %>
     <table class="CommentList">
-      <td style="width: 10%">
-        <%= image_tag comment.user.get_profile_image(100, 100), class: "rounded-circle" %>
+      <td style="width: 8%">
+        <%= image_tag comment.user.get_profile_image(50, 50), class: "rounded-circle" %>
       </td>
-      <td style="width: 10%">
-        <%= comment.user.name %>
+      <td style="width: 12%">
+        <%= comment.user.display_name %>
       </td>
       <td style="width: 70%">
-        <%= simple_format(h(comment.content)) %>
+        <%= simple_format(h(comment.content), class: "my-0") %>
       </td>
       <td class="text-center" style="width: 10%">
         <% if comment.user == current_user %>

--- a/app/views/public/notifications/_notification_list.html.erb
+++ b/app/views/public/notifications/_notification_list.html.erb
@@ -18,7 +18,6 @@
           <%= link_to "あなたの投稿", notification.post %>にコメントしました
         <% else %>
           <%= link_to post_path(notification.post) do %>
-            <%= image_tag notification.post.user.get_profile_image(100, 100) %>
             <%= notification.post.user.display_name %>さんの投稿
           <% end %>
           にコメントしました


### PR DESCRIPTION
コメント通知と表示の修正をしました。
主な変更点は下記の通りです。

（変更点）
・他の投稿に他のユーザーがコメントした際に、ユーザーの画像を通知一覧に表示しないよう修正
・コメント一覧のユーザー名が氏名で表示されていたため、修正
・コメント通知が自分を除く投稿者+他のコメントユーザーに送れるよう修正