### PR TITLE
投稿フォームのラジオボタンをラベルクリックで指定できるよう変更他

### DIFF
--- a/app/views/admin/posts/edit.html.erb
+++ b/app/views/admin/posts/edit.html.erb
@@ -42,10 +42,10 @@
         <%= f.text_area :body, placeholder: "宜しくお願いします", class: "form-control col-sm-6" %>
       </div>
       <div class="form-group field">
-        <%= f.label :"公開" %>
-        <%= f.radio_button :status, :public %><br>
-        <%= f.label :"非公開（下書き）" %>
+        <%= f.radio_button :status, :public %>
+        <%= f.label :status_public, "公開" %><br>
         <%= f.radio_button :status, :private %>
+        <%= f.label :status_private, "非公開（下書き）" %>
       </div>
       <%= f.submit "変更を保存する", class: "btn btn-success" %>
     <% end %>

--- a/app/views/public/posts/_form.html.erb
+++ b/app/views/public/posts/_form.html.erb
@@ -28,8 +28,8 @@
   <%= f.text_area :body, placeholder: "宜しくお願いします", class: "form-control col-sm-6" %>
 </div>
 <div class="form-group field">
-  <%= f.label :"公開" %>
-  <%= f.radio_button :status, :public %><br>
-  <%= f.label :"非公開（下書き）" %>
+  <%= f.radio_button :status, :public %>
+  <%= f.label :status_public, "公開" %><br>
   <%= f.radio_button :status, :private %>
+  <%= f.label :status_private, "非公開（下書き）" %>
 </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -109,7 +109,7 @@ ja:
     post:
       status:
         public: 公開
-        private: 非公開
+        private: 非公開（下書き）
   errors:
     format: "%{attribute}%{message}"
     messages:


### PR DESCRIPTION
投稿フォームのラジオボタンをラベルクリックで指定できるよう変更しました。
また、localeで投稿ステータスの「非公開」を「非公開（下書き）」に変更しました。