### PR TITLE
チャット画面のレイアウト調整他

### DIFF
--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -109,21 +109,21 @@
 
 .Message.Mine::after{
   right: 10px;
-  border-radius: 0px 0  0 17px/ 0px 0 0 13px; 
-  box-shadow: 14px 2px 0 -3px #fff inset; 
+  border-radius: 0px 0  0 17px/ 0px 0 0 13px;
+  box-shadow: 14px 2px 0 -3px #98d98e inset;
 }
 
-.Message.Yours::after{
+.Message.Others::after{
   left: 10px;
-  border-radius: 0px 0 17px 0/ 0px 0 13px 0; 
-  box-shadow: -14px 2px 0 -3px #fff inset; 
+  border-radius: 0px 0 17px 0/ 0px 0 13px 0;
+  box-shadow: -14px 2px 0 -3px #fff inset;
 }
 
 //コンテンツ量に関わらずフッターを最下部に表示 
 .FixedFooterBottom{
   min-height: 100vh; //コンテンツ高さの最小値=ブラウザの高さ
   position: relative; //footerを相対位置で指定
-  padding-bottom: 60px; //footer直上のコンテンツとの間隔
+  padding-bottom: 50px; //footer直上のコンテンツとの間隔
   box-sizing: border-box;
 }
 
@@ -133,5 +133,5 @@ footer{
   width: 100%;
   height: 50px;
   background-color: #365E94;
-  color: white;
+  color: #fff;
 }

--- a/app/views/admin/chats/_chat_list.html.erb
+++ b/app/views/admin/chats/_chat_list.html.erb
@@ -4,11 +4,11 @@
     <% if chat.user_id == chat.room.post.user.id %>
       <tr class="MyChat text-right">
         <td width="10%"></td>
-        <td class="Message Mine">
+        <td class="Message Mine" style="background-color: #98d98e;">
           <h6 class="text-left"><%= simple_format(h(chat.message)) %></h6>
-          <h6 style="color: #C0C0C0;"><%= chat.created_at.strftime("%Y/%m/%d %H:%M") %></h6>
+          <h6 style="color: #afafb0;"><%= chat.created_at.strftime("%Y/%m/%d %H:%M") %></h6>
         </td>
-        <td class="text-center", width="10%">
+        <td class="text-center align-bottom", width="10%">
           <%= link_to admin_user_path(chat.room.post.user) do %>
             <%= image_tag chat.room.post.user.get_profile_image(100, 100), class: "ChatUserImg" %><br>
             <%= chat.room.post.user.display_name %>
@@ -16,14 +16,14 @@
         </td>
       </tr>
     <% else %>
-      <tr class="YourChat text-left">
-        <td class="text-center", width="10%">
+      <tr class="OtherChat text-left">
+        <td class="text-center align-bottom", width="10%">
           <%= link_to admin_user_path(chat.user) do %>
             <%= image_tag chat.user.get_profile_image(100, 100), class: "ChatUserImg" %><br>
             <%= chat.user.display_name %>
           <% end %>
         </td>
-        <td class="Message Yours">
+        <td class="Message Others">
           <h6><%= simple_format(h(chat.message)) %></h6>
           <h6 style="color: #C0C0C0;"><%= chat.created_at.strftime("%Y/%m/%d %H:%M") %></h6>
         </td>

--- a/app/views/admin/rooms/show.html.erb
+++ b/app/views/admin/rooms/show.html.erb
@@ -1,5 +1,5 @@
 <!--ルーム詳細-->
-<div class="container-fluid w-75 py-3" style="background-color: #eaf4fc;">
+<div class="container-fluid w-75 py-3" style="background-color: #c1e4e9;">
   <div class="RoomBtn text-right">
     <%= link_to "削除", admin_room_path, method: :delete, "data-confirm" => "本当に削除しますか？", class: "btn btn-danger" %>
   </div>

--- a/app/views/public/chats/_chat_list.html.erb
+++ b/app/views/public/chats/_chat_list.html.erb
@@ -4,11 +4,11 @@
     <% if chat.user_id == current_user.id %>
       <tr class="MyChat text-right">
         <td width="10%"></td>
-        <td class="Message Mine">
+        <td class="Message Mine" style="background-color: #98d98e;">
           <h6 class="text-left"><%= simple_format(h(chat.message)) %></h6>
-          <h6 style="color: #C0C0C0;"><%= chat.created_at.strftime("%Y/%m/%d %H:%M") %></h6>
+          <h6 style="color: #afafb0;"><%= chat.created_at.strftime("%Y/%m/%d %H:%M") %></h6>
         </td>
-        <td class="text-center", width="10%">
+        <td class="text-center align-bottom", width="10%">
           <%= link_to user_path(chat.user) do %>
             <%= image_tag chat.user.get_profile_image(100, 100), class: "ChatUserImg" %><br>
             <%= simple_format(h(chat.user.display_name)) %>
@@ -16,14 +16,14 @@
         </td>
       </tr>
     <% else %>
-      <tr class="YourChat text-left">
-        <td class ="text-center", width="10%">
+      <tr class="OtherChat text-left">
+        <td class ="text-center align-bottom", width="10%">
           <%= link_to user_path(chat.user) do %>
             <%= image_tag chat.user.get_profile_image(100, 100), class: "ChatUserImg" %><br>
             <%= chat.user.display_name %>
           <% end %>
         </td>
-        <td class="Message Yours">
+        <td class="Message Others">
           <h6><%= simple_format(h(chat.message)) %></h6>
           <h6 style="color: #C0C0C0;"><%= chat.created_at.strftime("%Y/%m/%d %H:%M") %></h6>
         </td>

--- a/app/views/public/homes/about.html.erb
+++ b/app/views/public/homes/about.html.erb
@@ -15,6 +15,6 @@
   </p>
 </div>
 
-<div class="MainVisual w-100 px-0">
+<div class="MainVisual w-100 mb-3 px-0">
   <%= image_tag asset_path("about-image.jpg"), class: "img-responsive mx-auto d-block", width: "900", height: "500" %>
 </div>

--- a/app/views/public/rooms/show.html.erb
+++ b/app/views/public/rooms/show.html.erb
@@ -1,5 +1,5 @@
 <!--ルーム詳細-->
-<div class="container-fluid w-75" style="background-color: #eaf4fc;">
+<div class="container-fluid w-75" style="background-color: #c1e4e9;">
   <div class="RoomTitle text-center py-3">
     <% @user_rooms.each do |ur| %>
       <% if ur.user != current_user %>


### PR DESCRIPTION
チャット画面のレイアウト調整を行いました。
主な変更点は下記の通りです。

（変更点）
・カレントユーザー（管理者画面の場合、投稿者）のチャットフキダシが緑色になるよう変更
・クラスの命名を一部変更